### PR TITLE
Add the ability to override the oath key name

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,8 @@ Also make sure to have your MFA ARN configured for your profile:
 role_arn = arn:aws:iam::...
 mfa_serial = arn:aws:iam::...
 source_profile = default
+# You can also override the key name (useful if you used a "friendly" key name for when you're using the console)
+oath_key_name = shinykey
 ```
 
 

--- a/README.md
+++ b/README.md
@@ -29,6 +29,10 @@ $ pip install --user awscli-plugin-yubikeytotp
 To enable the plugin, add this to your `~/.aws/config`:
 ```
 [plugins]
+# The next line is required if you are using CLI v2
+# Use the path that `pip` installed the package to - this one is in user mode
+cli_legacy_plugin_path = /home/myhomefolder/.local/lib/python3.8/site-packages/
+
 yubikeytotp = awscli_plugin_yubikeytotp
 ```
 Also make sure to have your MFA ARN configured for your profile:

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ role_arn = arn:aws:iam::...
 mfa_serial = arn:aws:iam::...
 source_profile = default
 # You can also override the key name (useful if you used a "friendly" key name for when you're using the console)
-oath_key_name = shinykey
+mfa_alias = shinykey
 ```
 
 

--- a/awscli_plugin_yubikeytotp/prompter.py
+++ b/awscli_plugin_yubikeytotp/prompter.py
@@ -26,8 +26,9 @@ except ImportError:
 
 
 class YubikeyTotpPrompter(object):
-    def __init__(self, mfa_serial, original_prompter=None):
+    def __init__(self, mfa_serial, oath_key_name, original_prompter=None):
         self.mfa_serial = mfa_serial
+        self.oath_key_name = oath_key_name
         self._original_prompter = original_prompter
 
     def __call__(self, prompt):
@@ -36,13 +37,13 @@ class YubikeyTotpPrompter(object):
                 ["ykman", "oath", "list"], capture_output=True, check=True
             )
             available_keys = available_keys_result.stdout.decode("utf-8").split()
-            available_keys.index(self.mfa_serial)
+            available_keys.index(self.oath_key_name)
 
             console_print(
                 "Generating OATH code on YubiKey. You may have to touch your YubiKey to proceed..."
             )
             ykman_result = subprocess.run(
-                ["ykman", "oath", "code", "-s", self.mfa_serial], capture_output=True
+                ["ykman", "oath", "code", "-s", self.oath_key_name], capture_output=True
             )
             console_print("Successfully created OATH code.")
             token = ykman_result.stdout.decode("utf-8").strip()
@@ -69,12 +70,15 @@ def inject_yubikey_totp_prompter(session, **kwargs):
 
     config = session.get_scoped_config()
     mfa_serial = config.get("mfa_serial")
+    oath_key_name = config.get("oath_key_name")
     if mfa_serial is None:
         # no MFA, so don't interfere with regular flow
         return
 
+    if oath_key_name is None:
+        oath_key_name = mfa_serial
     assume_role_provider = providers.get_provider("assume-role")
     original_prompter = assume_role_provider._prompter
     assume_role_provider._prompter = YubikeyTotpPrompter(
-        mfa_serial, original_prompter=original_prompter
+        mfa_serial, oath_key_name, original_prompter=original_prompter
     )


### PR DESCRIPTION
Found myself wanting to do this when I set a "friendly" key name
when setting up my key at the console.

You can't rename or export TOTP keys once they're in your YubiKey,
and my current client has a *really* annoying workflow for resetting
MFA keys, so rather than go through all that and wait another day for
my console access to work and be easy, I added an option to the plugin.

Also : small note about getting plugin to work on CLI v2, which has
changed how the plugin lookup path works because they went for the
"unpack an archive" install route.

Plugin still works fine on v2 at present.